### PR TITLE
Proposal: After Squeak was shut down unexpectedly, propose to restore changes

### DIFF
--- a/repository/Vivide.package/VivideLight.class/class/startUp..st
+++ b/repository/Vivide.package/VivideLight.class/class/startUp..st
@@ -5,6 +5,11 @@ startUp: resuming
 		ifTrue: [
 			self active
 				ifNotNil: [#recoverUnsavedScripts openScript]
-				ifNil: [self inform: 'Squeak was shut down unexpectedly.']].
-
+				ifNil: [(Project current uiManager
+						chooseFromLabeledValues: (OrderedDictionary newFrom: {
+							'Ignore' -> [].
+							'Restore changes' -> [ChangeList browseRecentLog]
+						})
+						title: 'Squeak was shut down unexpectedly.') value]].
+	
 	FileStream forceNewFileNamed: 'vivide.ok' do: [:stream | ].

--- a/repository/Vivide.package/VivideLight.class/methodProperties.json
+++ b/repository/Vivide.package/VivideLight.class/methodProperties.json
@@ -21,7 +21,7 @@
 		"prepareSqueak" : "mt 8/25/2016 15:24",
 		"profiles" : "mt 1/31/2015 13:09",
 		"shutDown:" : "mt 10/19/2015 10:33:11",
-		"startUp:" : "mt 7/13/2019 11:39",
+		"startUp:" : "ct 8/30/2020 13:54",
 		"unload" : "mt 2/6/2018 19:08",
 		"useClassicMode" : "mt 12/15/2015 09:42:45.958",
 		"useClassicMode:" : "mt 12/9/2014 16:01:29.602",


### PR DESCRIPTION
The `vivide.ok` mechanism is really helpful to me even if not using VivideLight actively, but every time I am notified that Squeak was shut down unexpectedly, my first way leads me to the change list where I can restore the lost changes. For this reason, in my image, I added a link to this tool directly from the message. Maybe this could be helpful for other Vivide users as well? :-)